### PR TITLE
Minor: fix cd . and hitting return without ERROR

### DIFF
--- a/js/cli.js
+++ b/js/cli.js
@@ -70,7 +70,7 @@ commands.cd = (newDirectory) => {
     setDirectory(newDir)
   } else if (newDir === '' || newDir === '~' || (newDir === '..' && dirs.includes(currDir))) {
     setDirectory('root')
-  } else {
+  } else if (newDir !== '.') {
     return errors.invalidDirectory
   }
   return null

--- a/js/shell.js
+++ b/js/shell.js
@@ -91,7 +91,7 @@ class Shell {
           this.resetPrompt(term, prompt)
           $('.root').last().html(localStorage.directory)
         } else {
-          this.term.innerHTML += 'Error: command not recognized'
+          this.term.innerHTML += cmd ? 'Error: command not recognized' : '';
           this.resetPrompt(term, prompt)
         }
         evt.preventDefault()


### PR DESCRIPTION
Super minor fixes: `cd .` or hitting return returned `ERROR: command not found` error so far. This PR fixes them.

I think this repo is an amazing idea, Thanks!