### PR TITLE
feat: add minimize toggle and update styles

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -27,6 +27,11 @@ const registerFullscreenToggle = () => {
     $('.terminal-window').toggleClass('fullscreen');
   });
 };
+const registerMinimizedToggle = () => {
+  $('.button.yellow').click(() => {
+    $('.terminal-window').toggleClass('minimized')
+  })
+};
 
 // Create new directory in current directory.
 commands.mkdir = () => errors.noWriteAccess;
@@ -95,6 +100,7 @@ commands.cat = (filename) => {
 // Initialize cli.
 $(() => {
   registerFullscreenToggle();
+  registerMinimizedToggle()
   const cmd = document.getElementById('terminal');
 
   $.ajaxSetup({ cache: false });

--- a/styles/main.less
+++ b/styles/main.less
@@ -13,23 +13,21 @@ body {
   position: relative;
   display: block;
   top: 25vh;
+  transition: all 0.5s ease;
 
+  &.minimized {
+    height: 30px;
+    top: calc(100vh - 38px);
+    width: 250px;
+  }
+  
   &.fullscreen {
     z-index: 9999;
     width: 100%;
     height: 100%;
-    position: fixed;
     top: 0;
     left: 0;
-
-    header {
-      display: none;
-    }
-
-    #terminal {
-      top: 0;
-    }
-   }
+  }
 
   header {
     background: #e0e8f0;
@@ -52,6 +50,7 @@ body {
 
     .button.yellow {
       background: #e5c30f;
+      cursor: pointer;
     }
 
     .button.red {
@@ -126,13 +125,14 @@ body {
 }
 
 .footer {
-  position: fixed;
-  bottom: 0;
+  position: absolute;
+  bottom: 40px;
+  left: 0;
+  right: 0;
   text-align: center;
   line-height: 0.1px;
-  width: 100%;
   color: white;
-  font-family: @font-family;
+  font-family: Menlo, Monaco, "Consolas", "Courier New", "Courier";
 
   .site-code {
     font-weight: bold;

--- a/styles/main.less
+++ b/styles/main.less
@@ -1,4 +1,4 @@
-@font-family: "Lato", Georgia, Serif;
+@font-family: Menlo, Monaco, "Consolas", "Courier New", "Courier";
 
 body {
   background-color: #211E3A;
@@ -60,7 +60,7 @@ body {
 
   #terminal {
     color: white;
-    font-family: Menlo, Monaco, "Consolas", "Courier New", "Courier";
+    font-family: @font-family;
     font-size: 11pt;
     background: #30353a;
     padding: 10px;
@@ -132,7 +132,7 @@ body {
   text-align: center;
   line-height: 0.1px;
   color: white;
-  font-family: Menlo, Monaco, "Consolas", "Courier New", "Courier";
+  font-family: @font-family;
 
   .site-code {
     font-weight: bold;


### PR DESCRIPTION
My ideas for the update are listed within the issue I made in January: https://github.com/codebytere/codebytere.github.io/issues/17

**Here's a quick summary anyways:**
- Fullscreen shouldn't completely remove the frame
  - Remove position fixed from terminal window
  - Remove top 0 from terminal window
  - Animate the window resizing
- Adding functionality to the minimise button
  - Add css/less minimised state
  - Add the pointer while hovering the minimised button
  - Add functionality to the button
- Footer looks nice when it matches the site-wide font.
  - Change Lato for Menlo, add enough room from the bottom for the minimised state, and also make your position absolute so that the footer is actually centred and not off by a wee bit.