### PR TITLE
fix: footer overlapping window via z-index

### DIFF
--- a/styles/main.less
+++ b/styles/main.less
@@ -14,6 +14,7 @@ body {
   display: block;
   top: 25vh;
   transition: all 0.5s ease;
+  z-index: 999;
 
   &.minimized {
     height: 30px;
@@ -22,7 +23,6 @@ body {
   }
   
   &.fullscreen {
-    z-index: 9999;
     width: 100%;
     height: 100%;
     top: 0;


### PR DESCRIPTION
Removed z-index from fullscreen, and just moved it to the terminal-window. This fixes the footer overlapping the window.