### PR TITLE
ls does not understand argument

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -48,6 +48,11 @@ commands.ls = (directory) => {
   if (directory === '..' || directory === '~') {
     return systemData['root'];
   }
+
+  if (directory in struct) {
+    return systemData[directory];
+  }
+
   return systemData[getDirectory()];
 };
 
@@ -89,7 +94,6 @@ commands.cat = (filename) => {
 
   const dir = getDirectory();
   const fileKey = filename.split('.')[0];
-
   if (fileKey in systemData && struct[dir].includes(fileKey)) {
     return systemData[fileKey];
   }


### PR DESCRIPTION
Closes #27.

Fixes an issue whereby `ls` did not properly print the contents of a directory one was not currently in. 