### PR TITLE
fix: add 'clear' to terminal history

### DIFF
--- a/pages/familiar.html
+++ b/pages/familiar.html
@@ -1,4 +1,4 @@
-"<ul>
+<ul>
   <li>React</li>
   <li>Sketch</li>
 </ul>

--- a/src/shell.js
+++ b/src/shell.js
@@ -91,6 +91,7 @@ class Shell {
         const args = input[1];
 
         if (cmd === 'clear') {
+          this.updateHistory(cmd);
           this.clearConsole();
         } else if (cmd && cmd in this.commands) {
           this.runCommand(cmd, args);


### PR DESCRIPTION
Hello,

I just found your way to present you very original and fun :)

So, I wanted to correct 2 little bugs on it

I am not satisfied on the way clear command is added in history, but I didn't wanted to start now a refactoring to handle clear as another command