### PR TITLE
fixed keyup and keydown bugs caused by local storage 

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -28,29 +28,27 @@ class Shell {
 
         if (key === keyUp) {
           if (localStorage.historyIndex >= 0) {
-            if (!localStorage.inHistory) {
+            if (localStorage.inHistory == 'false') {
               localStorage.inHistory = true;
-            } else {
-              // Prevent repetition of last command while traversing history.
-              if (localStorage.historyIndex === history.length - 1 && history.length !== 1) {
-                localStorage.historyIndex -= 1;
-              }
             }
+            // Prevent repetition of last command while traversing history.
+            if (localStorage.historyIndex == history.length - 1 && history.length !== 1) {
+              localStorage.historyIndex -= 1;
+            }
+            $('.input').last().html(`${history[localStorage.historyIndex]}<span class="end"><span>`);
+            if (localStorage.historyIndex != 0) localStorage.historyIndex -= 1;
           }
-
-          $('.input').last().html(`${history[localStorage.historyIndex]}<span class="end"><span>`);
-          if (localStorage.historyIndex !== 0) localStorage.historyIndex -= 1;
         } else if (key === keyDown) {
-          if (localStorage.inHistory && localStorage.historyIndex < history.length) {
+          if (localStorage.inHistory == 'true' && localStorage.historyIndex < history.length) {
             let ret;
 
             if (localStorage.historyIndex > 0) {
               ret = `${history[localStorage.historyIndex]}<span class="end"><span>`;
-              if (localStorage.historyIndex !== history.length - 1) {
+              if (localStorage.historyIndex != history.length - 1) {
                 localStorage.historyIndex = Number(localStorage.historyIndex) + 1;
               }
               // Prevent repetition of first command while traversing history.
-            } else if (localStorage.historyIndex === 0 && history.length > 1) {
+            } else if (localStorage.historyIndex == 0 && history.length > 1) {
               ret = `${history[1]}<span class="end"><span>`;
               localStorage.historyIndex = history.length !== 2 ? 2 : 1;
             }

--- a/src/shell.js
+++ b/src/shell.js
@@ -35,7 +35,9 @@ class Shell {
             if (localStorage.historyIndex == history.length - 1 && history.length !== 1) {
               localStorage.historyIndex -= 1;
             }
-            $('.input').last().html(`${history[localStorage.historyIndex]}<span class="end"><span>`);
+            $('.input')
+              .last()
+              .html(`${history[localStorage.historyIndex]}<span class="end"><span>`);
             if (localStorage.historyIndex != 0) localStorage.historyIndex -= 1;
           }
         } else if (key === keyDown) {


### PR DESCRIPTION
Fixed bug related to keyup and keydown. 

https://github.com/codebytere/codebytere.github.io/issues/38
https://github.com/codebytere/codebytere.github.io/issues/16

root cause: number and boolean variables are saved as strings in local storage. Thus, a strong type comparison should be replaced by a weak comparison. 

Apart from these, fixed another issue that the first time press a keyup only enters history mode but does not show history command. 

