### PR TITLE
Remove outline in focus

### DIFF
--- a/styles/main.less
+++ b/styles/main.less
@@ -70,6 +70,10 @@ body {
     top: 30px;
     bottom: 0;
     overflow: auto;
+    
+    span.input:focus-visible {
+      outline: none;
+    }
   }
 
   .contact {


### PR DESCRIPTION
Remove outline in `focus-visible` to show terminal cursor.

Before:
![before](https://firebasestorage.googleapis.com/v0/b/myself-dg.appspot.com/o/extras%2FScreen%20Shot%202022-09-15%20at%2019.38.06.png?alt=media&token=50e5bcf9-8ed3-4776-9e63-21276ee6019f)

After:
![after](https://firebasestorage.googleapis.com/v0/b/myself-dg.appspot.com/o/extras%2FScreen%20Shot%202022-09-15%20at%2019.39.00.png?alt=media&token=b5c5d6ba-cef7-43c1-bf17-e7ce181d843c)